### PR TITLE
Add module headers for Olympus Abilities, Constants, and Debug files

### DIFF
--- a/Olympus/Olympus_Abilities.lua
+++ b/Olympus/Olympus_Abilities.lua
@@ -1,3 +1,5 @@
+-- Olympus Abilities
+
 ---Handle Sprint usage while moving
 ---@return boolean cast Whether Sprint was cast
 function Olympus.HandleSprint()

--- a/Olympus/Olympus_Constants.lua
+++ b/Olympus/Olympus_Constants.lua
@@ -1,3 +1,4 @@
+-- Olympus Constants
 Olympus = {}
 
 -- Debug categories specific to Olympus core functionality

--- a/Olympus/Olympus_Debug.lua
+++ b/Olympus/Olympus_Debug.lua
@@ -1,3 +1,4 @@
+-- Olympus Debug
 Debug = {
     -- Debug categories
     CATEGORIES = {


### PR DESCRIPTION
Introduce module headers to improve organization and clarity in the Olympus codebase.