### PR TITLE
Remove Project Remedy workspace configuration file

### DIFF
--- a/CombatRoutines/Project Remedy.code-workspace
+++ b/CombatRoutines/Project Remedy.code-workspace
@@ -1,8 +1,0 @@
-{
-	"folders": [
-		{
-			"path": ".."
-		}
-	],
-	"settings": {}
-}


### PR DESCRIPTION
Eliminate the workspace configuration file for Project Remedy to streamline project setup.