### PR TITLE
Refactor MP conservation logic in Apollo_MP.lua

### DIFF
--- a/CombatRoutines/Apollo_MP.lua
+++ b/CombatRoutines/Apollo_MP.lua
@@ -119,18 +119,18 @@ function Apollo.MP.HandleMPConservation()
     if Player.mp.percent <= Apollo.MP.THRESHOLDS.LUCID then
         local lucidDreaming = Apollo.Constants.SPELLS.LUCID_DREAMING
         
-        -- Debug print to help troubleshoot
         Debug.Info(Debug.CATEGORIES.COMBAT, string.format(
             "Checking Lucid - MP: %d%%, Spell Ready: %s, Spell Enabled: %s",
             Player.mp.percent,
-            tostring(Olympus.IsSpellReady(lucidDreaming.id)),
+            tostring(Olympus.IsReady(lucidDreaming.id, lucidDreaming)),
             tostring(Apollo.IsSpellEnabled("LUCID_DREAMING"))
         ))
 
-        if Apollo.IsSpellEnabled("LUCID_DREAMING") and Olympus.IsSpellReady(lucidDreaming.id) then
-            return Olympus.Cast(lucidDreaming.id)
+        if Apollo.IsSpellEnabled("LUCID_DREAMING") and Olympus.IsReady(lucidDreaming.id, lucidDreaming) then
+            return Olympus.CastAction(lucidDreaming)
         end
     end
+    
+    Debug.TrackFunctionEnd("Apollo.HandleMPConservation")
     return false
 end
-


### PR DESCRIPTION
- Updated the handling of the LUCID_DREAMING spell to improve checks for spell readiness and enablement.
- Replaced the previous method of checking spell readiness with a more streamlined approach using Olympus.IsReady.
- Enhanced debug logging to track function execution more effectively.
- Cleaned up unnecessary comments and ensured proper formatting.